### PR TITLE
Add tests for semantic ordering after creation on top of lifeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target/
 tests/**/.metadata/
 **/src/site/resources/images/rcptt-screenshots
 .vscode
+**/.polyglot.build.properties

--- a/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/Vertex.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.graph/src/org/eclipse/papyrus/uml/interaction/graph/Vertex.java
@@ -15,7 +15,6 @@ package org.eclipse.papyrus.uml.interaction.graph;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.gmf.runtime.notation.View;
@@ -100,7 +99,6 @@ public interface Vertex extends Visitable<Vertex>, Taggable {
 	 * @return whether I succeed the {@code other} in the interaction
 	 */
 	default boolean succeeds(Vertex other) {
-		predecessors().collect(Collectors.toList());
 		return predecessors().anyMatch(other::equals);
 	}
 

--- a/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
+++ b/plugins/org.eclipse.papyrus.uml.interaction.model/src/org/eclipse/papyrus/uml/interaction/internal/model/commands/InsertExecutionCommand.java
@@ -180,17 +180,43 @@ public class InsertExecutionCommand extends ModelCommand<MLifelineImpl> implemen
 
 		// Now we have commands to add the execution specification. But, first we must make
 		// room for it in the diagram. Nudge the element that will follow the new execution
-
-		MElement<?> distanceFrom = insertionPoint;
-		Optional<Command> makeSpace = getTarget().following(insertionPoint).map(el -> {
-			OptionalInt distance = el.verticalDistance(distanceFrom);
-			return distance.isPresent() ? el.nudge(height) : null;
-		});
+		Optional<Command> makeSpace = createNudgeCommand(insertionPoint, execParams.isInsertBefore());
 		if (makeSpace.isPresent()) {
 			result = makeSpace.get().chain(result);
 		}
 
 		return result;
+	}
+
+	/**
+	 * Creates the nudge command for the insertion of the execution.
+	 * <p>
+	 * If the insertion of the execution <code>isInsertBefore</code>, the <code>insertionPoint</code> also
+	 * needs to be nudged, otherwise we need to nudge everything after the insertion point.
+	 * </p>
+	 * 
+	 * @param insertionPoint
+	 *            the insertion point of the execution's insert command.
+	 * @param isInsertBefore
+	 *            whether or not, the insert command inserted before or after the insertion point.
+	 * @return the nudge command.
+	 */
+	protected Optional<Command> createNudgeCommand(MElement<? extends Element> insertionPoint,
+			boolean isInsertBefore) {
+		final MElement<? extends Element> nudgeStart;
+		if (isInsertBefore) {
+			nudgeStart = getTarget().preceding(insertionPoint).orElse(before);
+		} else {
+			nudgeStart = insertionPoint;
+		}
+
+		MElement<?> distanceFrom = insertionPoint;
+		Optional<Command> makeSpace = getTarget().following(nudgeStart).map(el -> {
+			OptionalInt distance = el.verticalDistance(distanceFrom);
+			return distance.isPresent() ? el.nudge(height) : null;
+		});
+
+		return makeSpace;
 	}
 
 	/**

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/ModelEditFixture.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/ModelEditFixture.java
@@ -1,0 +1,88 @@
+/*****************************************************************************
+ * Copyright (c) 2018 EclipseSource and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Philip Langer - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.tests;
+
+import java.util.Optional;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.gmf.runtime.notation.View;
+import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
+import org.eclipse.papyrus.uml.interaction.model.MElement;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.MMessage;
+import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
+import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture.Edit;
+import org.eclipse.uml2.uml.Element;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.InteractionFragment;
+import org.eclipse.uml2.uml.Message;
+
+@SuppressWarnings("restriction")
+public class ModelEditFixture extends Edit {
+
+	public DiagramHelper diagramHelper() {
+		return LogicalModelPlugin.getInstance().getDiagramHelper(this.getEditingDomain());
+	}
+
+	public LayoutHelper layoutHelper() {
+		return LogicalModelPlugin.getInstance().getLayoutHelper(this.getEditingDomain());
+	}
+
+	public int getLifelineBodyTop(MLifeline lifeline) {
+		View shape = lifeline.getDiagramView().orElse(null);
+		return layoutHelper().getTop(diagramHelper().getLifelineBodyShape(shape));
+	}
+
+	public MInteraction getMInteraction() {
+		return MInteraction.getInstance(getInteraction(), getSequenceDiagram().get());
+	}
+
+	public Optional<MMessage> getMMessage(Message message) {
+		return getMInteraction().getMessage(message);
+	}
+
+	public Optional<MExecution> getMExecution(ExecutionSpecification execution) {
+		Optional<MElement<? extends ExecutionSpecification>> element = getMInteraction()
+				.getElement(execution);
+		if (element.isPresent() && element.get() instanceof MExecution) {
+			return Optional.of((MExecution)element.get());
+		}
+		return Optional.empty();
+	}
+
+	public <T extends MElement<? extends Element>> T getElement(String qnFormat, String name, Class<T> type) {
+		String qName = String.format(qnFormat, name);
+
+		Element element = getElement(qName);
+		return Optional.ofNullable(element).flatMap(getMInteraction()::getElement).filter(type::isInstance)
+				.map(type::cast).orElseThrow(() -> new AssertionError("no such element: " + name)); //$NON-NLS-1$
+	}
+
+	@SuppressWarnings("unchecked")
+	public <T extends MElement<? extends Element>> T getElement(String qnFormat, String name) {
+		return (T)getElement(qnFormat, name, MElement.class);
+	}
+
+	@SuppressWarnings({"boxing" })
+	public Object isSemanticallyBefore(MOccurrence<? extends Element> one,
+			MOccurrence<? extends Element> other) {
+		EList<InteractionFragment> fragments = getMInteraction().getElement().getFragments();
+		int indexOfOne = fragments.indexOf(one.getElement());
+		int indexOfOther = getMInteraction().getElement().getFragments().indexOf(other.getElement());
+		return indexOfOne >= 0 && indexOfOther >= 0 && indexOfOther > indexOfOne;
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/ModelEditFixture.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/ModelEditFixture.java
@@ -11,9 +11,9 @@
  *****************************************************************************/
 package org.eclipse.papyrus.uml.interaction.model.tests;
 
+import java.util.List;
 import java.util.Optional;
 
-import org.eclipse.emf.common.util.EList;
 import org.eclipse.gmf.runtime.notation.View;
 import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
 import org.eclipse.papyrus.uml.interaction.model.MElement;
@@ -79,9 +79,9 @@ public class ModelEditFixture extends Edit {
 	@SuppressWarnings({"boxing" })
 	public Object isSemanticallyBefore(MOccurrence<? extends Element> one,
 			MOccurrence<? extends Element> other) {
-		EList<InteractionFragment> fragments = getMInteraction().getElement().getFragments();
+		List<InteractionFragment> fragments = getMInteraction().getElement().getFragments();
 		int indexOfOne = fragments.indexOf(one.getElement());
-		int indexOfOther = getMInteraction().getElement().getFragments().indexOf(other.getElement());
+		int indexOfOther = fragments.indexOf(other.getElement());
 		return indexOfOne >= 0 && indexOfOther >= 0 && indexOfOther > indexOfOne;
 	}
 

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
@@ -17,6 +17,7 @@ import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests.Logical
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateExecutionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateMessageTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateMessageTestB;
+import org.eclipse.papyrus.uml.interaction.model.tests.creation.SemanticOrderAfterCreationOfElementOnTopTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.BasicDeletionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.CreationMessageDeletionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.DeleteExecutionTest;
@@ -37,6 +38,7 @@ import org.junit.runners.Suite.SuiteClasses;
 		CreateMessageTest.class, CreateMessageTestB.class, //
 		CreateExecutionTest.class, DeleteExecutionTest.class, //
 		CreationMessageDeletionTest.class, BasicDeletionTest.class, DeletionMessageDeletionTest.class, //
+		SemanticOrderAfterCreationOfElementOnTopTest.class, //
 		LogicalModelAdapterTest.class, //
 		LogicalModelPredicatesTest.class, //
 })

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
@@ -19,6 +19,7 @@ import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateMessageTes
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateMessageTestB;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.BasicDeletionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.CreationMessageDeletionTest;
+import org.eclipse.papyrus.uml.interaction.model.tests.deletion.DeleteExecutionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.DeletionMessageDeletionTest;
 import org.eclipse.papyrus.uml.interaction.model.util.tests.LogicalModelPredicatesTest;
 import org.junit.runner.RunWith;
@@ -34,7 +35,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({ //
 		DefaultLayoutHelperTest.class, //
 		CreateMessageTest.class, CreateMessageTestB.class, //
-		CreateExecutionTest.class, //
+		CreateExecutionTest.class, DeleteExecutionTest.class, //
 		CreationMessageDeletionTest.class, BasicDeletionTest.class, DeletionMessageDeletionTest.class, //
 		LogicalModelAdapterTest.class, //
 		LogicalModelPredicatesTest.class, //

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/SeqDCustomTests.java
@@ -14,6 +14,7 @@ package org.eclipse.papyrus.uml.interaction.model.tests;
 
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests.DefaultLayoutHelperTest;
 import org.eclipse.papyrus.uml.interaction.internal.model.spi.impl.tests.LogicalModelAdapterTest;
+import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateExecutionTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateMessageTest;
 import org.eclipse.papyrus.uml.interaction.model.tests.creation.CreateMessageTestB;
 import org.eclipse.papyrus.uml.interaction.model.tests.deletion.BasicDeletionTest;
@@ -33,6 +34,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({ //
 		DefaultLayoutHelperTest.class, //
 		CreateMessageTest.class, CreateMessageTestB.class, //
+		CreateExecutionTest.class, //
 		CreationMessageDeletionTest.class, BasicDeletionTest.class, DeletionMessageDeletionTest.class, //
 		LogicalModelAdapterTest.class, //
 		LogicalModelPredicatesTest.class, //

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
@@ -17,6 +17,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 @ModelResource({"CreateExecutionTesting.uml", "CreateExecutionTesting.notation" })
+@SuppressWarnings("boxing")
 public class CreateExecutionTest {
 
 	private static final int EXECUTION_HEIGHT = 20;
@@ -49,17 +50,16 @@ public class CreateExecutionTest {
 		return interaction;
 	}
 
-	private void execute(Command remove) {
-		if (!remove.canExecute()) {
+	private void execute(Command command) {
+		if (!command.canExecute()) {
 			Assert.fail("Command not executable"); //$NON-NLS-1$
 		}
-		remove.execute();
+		command.execute();
 		/* force reinit after change */
 		interaction = null;
 	}
 
 	@Test
-	@SuppressWarnings("boxing")
 	public void creationExecutionOnTopOfLifeline1() {
 		/* setup */
 		MLifeline lifeline1 = interaction().getLifelines().get(0);
@@ -81,7 +81,6 @@ public class CreateExecutionTest {
 	}
 
 	@Test
-	@SuppressWarnings("boxing")
 	public void creationExecutionOnTopOfLifeline2() {
 		/* setup */
 		MLifeline lifeline2 = interaction().getLifelines().get(1);
@@ -103,7 +102,6 @@ public class CreateExecutionTest {
 	}
 
 	@Test
-	@SuppressWarnings("boxing")
 	public void creationExecutionAfterMessage1OnLifeline1() {
 		/* setup */
 		MLifeline lifeline1 = interaction().getLifelines().get(0);
@@ -125,7 +123,6 @@ public class CreateExecutionTest {
 	}
 
 	@Test
-	@SuppressWarnings("boxing")
 	public void creationExecutionAfterMessage1OnLifeline2() {
 		/* setup */
 		MLifeline lifeline2 = interaction().getLifelines().get(1);

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
@@ -19,10 +19,9 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
-import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.eclipse.uml2.uml.ExecutionSpecification;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,7 +33,7 @@ public class CreateExecutionTest {
 	private static final int EXECUTION_HEIGHT = 20;
 
 	@Rule
-	public final ModelFixture.Edit model = new ModelFixture.Edit();
+	public final ModelEditFixture model = new ModelEditFixture();
 
 	private MInteraction interaction;
 
@@ -56,16 +55,13 @@ public class CreateExecutionTest {
 
 	private MInteraction interaction() {
 		if (interaction == null) {
-			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+			interaction = model.getMInteraction();
 		}
 		return interaction;
 	}
 
 	private void execute(Command command) {
-		if (!command.canExecute()) {
-			Assert.fail("Command not executable"); //$NON-NLS-1$
-		}
-		command.execute();
+		model.execute(command);
 		/* force reinit after change */
 		interaction = null;
 	}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
@@ -1,0 +1,148 @@
+package org.eclipse.papyrus.uml.interaction.model.tests.creation;
+
+import static org.eclipse.uml2.uml.UMLPackage.Literals.ACTION_EXECUTION_SPECIFICATION;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+@ModelResource({"CreateExecutionTesting.uml", "CreateExecutionTesting.notation" })
+public class CreateExecutionTest {
+
+	private static final int EXECUTION_HEIGHT = 20;
+
+	@Rule
+	public final ModelFixture.Edit model = new ModelFixture.Edit();
+
+	private MInteraction interaction;
+
+	private int message1Top;
+
+	private int message2Top;
+
+	private int message3Top;
+
+	private int message4Top;
+
+	@Before
+	public void before() {
+		message1Top = interaction().getMessages().get(0).getTop().getAsInt();
+		message2Top = interaction().getMessages().get(1).getTop().getAsInt();
+		message3Top = interaction().getMessages().get(2).getTop().getAsInt();
+		message4Top = interaction().getMessages().get(3).getTop().getAsInt();
+	}
+
+	private MInteraction interaction() {
+		if (interaction == null) {
+			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+		}
+		return interaction;
+	}
+
+	private void execute(Command remove) {
+		if (!remove.canExecute()) {
+			Assert.fail("Command not executable"); //$NON-NLS-1$
+		}
+		remove.execute();
+		/* force reinit after change */
+		interaction = null;
+	}
+
+	@Test
+	@SuppressWarnings("boxing")
+	public void creationExecutionOnTopOfLifeline1() {
+		/* setup */
+		MLifeline lifeline1 = interaction().getLifelines().get(0);
+		CreationCommand<ExecutionSpecification> command = lifeline1.insertExecutionAfter(lifeline1, 10,
+				EXECUTION_HEIGHT, ACTION_EXECUTION_SPECIFICATION);
+
+		/* act */
+		execute(command);
+
+		/* assert: All messages moved down */
+		assertThat(interaction().getMessages().get(0).getTop().getAsInt(),
+				is(message1Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(1).getTop().getAsInt(),
+				is(message2Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(2).getTop().getAsInt(),
+				is(message3Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(3).getTop().getAsInt(),
+				is(message4Top + EXECUTION_HEIGHT));
+	}
+
+	@Test
+	@SuppressWarnings("boxing")
+	public void creationExecutionOnTopOfLifeline2() {
+		/* setup */
+		MLifeline lifeline2 = interaction().getLifelines().get(1);
+		CreationCommand<ExecutionSpecification> command = lifeline2.insertExecutionAfter(lifeline2, 0,
+				EXECUTION_HEIGHT, ACTION_EXECUTION_SPECIFICATION);
+
+		/* act */
+		execute(command);
+
+		/* assert: All messages moved down */
+		assertThat(interaction().getMessages().get(0).getTop().getAsInt(),
+				is(message1Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(1).getTop().getAsInt(),
+				is(message2Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(2).getTop().getAsInt(),
+				is(message3Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(3).getTop().getAsInt(),
+				is(message4Top + EXECUTION_HEIGHT));
+	}
+
+	@Test
+	@SuppressWarnings("boxing")
+	public void creationExecutionAfterMessage1OnLifeline1() {
+		/* setup */
+		MLifeline lifeline1 = interaction().getLifelines().get(0);
+		CreationCommand<ExecutionSpecification> command = lifeline1.insertExecutionAfter(
+				interaction().getMessages().get(0), 0, EXECUTION_HEIGHT, ACTION_EXECUTION_SPECIFICATION);
+
+		/* act */
+		execute(command);
+
+		/* assert: message 1 didn't move, message 2, 3 and 4 moved down */
+		assertThat(interaction().getMessages().get(0).getTop().getAsInt(), is(message1Top));
+
+		assertThat(interaction().getMessages().get(1).getTop().getAsInt(),
+				is(message2Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(2).getTop().getAsInt(),
+				is(message3Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(3).getTop().getAsInt(),
+				is(message4Top + EXECUTION_HEIGHT));
+	}
+
+	@Test
+	@SuppressWarnings("boxing")
+	public void creationExecutionAfterMessage1OnLifeline2() {
+		/* setup */
+		MLifeline lifeline2 = interaction().getLifelines().get(1);
+		CreationCommand<ExecutionSpecification> command = lifeline2.insertExecutionAfter(
+				interaction().getMessages().get(0), 0, EXECUTION_HEIGHT, ACTION_EXECUTION_SPECIFICATION);
+
+		/* act */
+		execute(command);
+
+		/* assert: message 1 didn't move, message 2, 3 and 4 moved down */
+		assertThat(interaction().getMessages().get(0).getTop().getAsInt(), is(message1Top));
+
+		assertThat(interaction().getMessages().get(1).getTop().getAsInt(),
+				is(message2Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(2).getTop().getAsInt(),
+				is(message3Top + EXECUTION_HEIGHT));
+		assertThat(interaction().getMessages().get(3).getTop().getAsInt(),
+				is(message4Top + EXECUTION_HEIGHT));
+	}
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTest.java
@@ -1,3 +1,14 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Philip Langer and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Philip Langer - Initial API and implementation
+ *****************************************************************************/
 package org.eclipse.papyrus.uml.interaction.model.tests.creation;
 
 import static org.eclipse.uml2.uml.UMLPackage.Literals.ACTION_EXECUTION_SPECIFICATION;

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTesting.notation
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTesting.notation
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_kCqjwLA8EeiVu8M2BzYNdA" type="LightweightSequenceDiagram" name="Lightweight Sequence Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_kCqjwbA8EeiVu8M2BzYNdA" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_kCqjwrA8EeiVu8M2BzYNdA" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_kCqjw7A8EeiVu8M2BzYNdA" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_k3YlQLA8EeiVu8M2BzYNdA" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQbA8EeiVu8M2BzYNdA" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQrA8EeiVu8M2BzYNdA" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQ7A8EeiVu8M2BzYNdA" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_k3YlRLA8EeiVu8M2BzYNdA" width="150" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="CreateExecutionTesting.uml#_kxgmwLA8EeiVu8M2BzYNdA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k3YlRbA8EeiVu8M2BzYNdA" x="29" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_lH4fYLA8EeiVu8M2BzYNdA" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_lH4fYbA8EeiVu8M2BzYNdA" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_lH4fYrA8EeiVu8M2BzYNdA" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_lH4fY7A8EeiVu8M2BzYNdA" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_lH4fZLA8EeiVu8M2BzYNdA" width="150" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="CreateExecutionTesting.uml#_k9yvQLA8EeiVu8M2BzYNdA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lH4fZbA8EeiVu8M2BzYNdA" x="164" y="25" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kCqjxLA8EeiVu8M2BzYNdA" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_kCqjxbA8EeiVu8M2BzYNdA" name="diagram_compatibility_version" stringValue="1.3.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_kCqjxrA8EeiVu8M2BzYNdA"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_kCqjx7A8EeiVu8M2BzYNdA" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="CreateExecutionTesting.uml#_kCRiMLA8EeiVu8M2BzYNdA"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="CreateExecutionTesting.uml#_kCRiMLA8EeiVu8M2BzYNdA"/>
+  <edges xmi:type="notation:Connector" xmi:id="_mX-1ULA8EeiVu8M2BzYNdA" type="Edge_Message" source="_k3YlQ7A8EeiVu8M2BzYNdA" target="_lH4fY7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="CreateExecutionTesting.uml#_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX-1UbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX-1UrA8EeiVu8M2BzYNdA" id="98"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX-1U7A8EeiVu8M2BzYNdA" id="98"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_mzDnwLA8EeiVu8M2BzYNdA" type="Edge_Message" source="_lH4fY7A8EeiVu8M2BzYNdA" target="_k3YlQ7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="CreateExecutionTesting.uml#_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mzDnwbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mzDnwrA8EeiVu8M2BzYNdA" id="133"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mzDnw7A8EeiVu8M2BzYNdA" id="133"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_nM8HY7A8EeiVu8M2BzYNdA" type="Edge_Message" source="_k3YlQ7A8EeiVu8M2BzYNdA" target="_lH4fY7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="CreateExecutionTesting.uml#_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nM8HZLA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nM8HZbA8EeiVu8M2BzYNdA" id="191"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nM8HZrA8EeiVu8M2BzYNdA" id="191"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_nr-MwLA8EeiVu8M2BzYNdA" type="Edge_Message" source="_lH4fY7A8EeiVu8M2BzYNdA" target="_k3YlQ7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="CreateExecutionTesting.uml#_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nr-MwbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nr-MwrA8EeiVu8M2BzYNdA" id="220"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nr-Mw7A8EeiVu8M2BzYNdA" id="220"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTesting.uml
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateExecutionTesting.uml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_kBamkLA8EeiVu8M2BzYNdA" name="CreateExecutionTesting">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_kKeb8LA8EeiVu8M2BzYNdA">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_kCRiMLA8EeiVu8M2BzYNdA" name="Interaction1">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_kxgmwLA8EeiVu8M2BzYNdA" name="Lifeline1" coveredBy="_mX8ZELA8EeiVu8M2BzYNdA _mzBykLA8EeiVu8M2BzYNdA _nM8HYLA8EeiVu8M2BzYNdA _nr8XkLA8EeiVu8M2BzYNdA"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_k9yvQLA8EeiVu8M2BzYNdA" name="Lifeline2" coveredBy="_mX9AILA8EeiVu8M2BzYNdA _mzBLgLA8EeiVu8M2BzYNdA _nM8HYbA8EeiVu8M2BzYNdA _nr7wgLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mX8ZELA8EeiVu8M2BzYNdA" name="msg1_send" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mX9AILA8EeiVu8M2BzYNdA" name="msg1_receive" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mzBLgLA8EeiVu8M2BzYNdA" name="msg2_send" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mzBykLA8EeiVu8M2BzYNdA" name="msg2_receive" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nM8HYLA8EeiVu8M2BzYNdA" name="msg3_send" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nM8HYbA8EeiVu8M2BzYNdA" name="msg3_receive" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nr7wgLA8EeiVu8M2BzYNdA" name="msg4_send" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nr8XkLA8EeiVu8M2BzYNdA" name="msg4_receive" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_mX9nMLA8EeiVu8M2BzYNdA" name="msg1" receiveEvent="_mX9AILA8EeiVu8M2BzYNdA" sendEvent="_mX8ZELA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_mzCZoLA8EeiVu8M2BzYNdA" name="ms2" receiveEvent="_mzBykLA8EeiVu8M2BzYNdA" sendEvent="_mzBLgLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_nM8HYrA8EeiVu8M2BzYNdA" name="msg3" receiveEvent="_nM8HYbA8EeiVu8M2BzYNdA" sendEvent="_nM8HYLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_nr8-oLA8EeiVu8M2BzYNdA" name="msg4" receiveEvent="_nr8XkLA8EeiVu8M2BzYNdA" sendEvent="_nr7wgLA8EeiVu8M2BzYNdA"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTest.java
@@ -3,29 +3,23 @@ package org.eclipse.papyrus.uml.interaction.model.tests.creation;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.gmf.runtime.notation.View;
-import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
-import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
-import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
-import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.MessageSort;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-@SuppressWarnings("restriction")
 @ModelResource({"CreateMessageTesting.uml", "CreateMessageTesting.notation" })
 public class CreateMessageTest {
 
 	@Rule
-	public final ModelFixture.Edit model = new ModelFixture.Edit();
+	public final ModelEditFixture model = new ModelEditFixture();
 
 	private MInteraction interaction;
 
@@ -57,8 +51,8 @@ public class CreateMessageTest {
 		lifeline2Top = interaction().getLifelines().get(1).getTop().getAsInt();
 		lifeline3Top = interaction().getLifelines().get(2).getTop().getAsInt();
 
-		lifeline2Header = getLifelineBodyTop(interaction().getLifelines().get(1)) - lifeline2Top;
-		lifeline3Header = getLifelineBodyTop(interaction().getLifelines().get(2)) - lifeline3Top;
+		lifeline2Header = model.getLifelineBodyTop(interaction().getLifelines().get(1)) - lifeline2Top;
+		lifeline3Header = model.getLifelineBodyTop(interaction().getLifelines().get(2)) - lifeline3Top;
 
 		message1Top = interaction().getMessages().get(0).getTop().getAsInt();
 		message2Top = interaction().getMessages().get(1).getTop().getAsInt();
@@ -74,34 +68,17 @@ public class CreateMessageTest {
 				.getAsInt();
 	}
 
-	private DiagramHelper diagramHelper() {
-		return LogicalModelPlugin.getInstance().getDiagramHelper(model.getEditingDomain());
-	}
-
-	private LayoutHelper layoutHelper() {
-		return LogicalModelPlugin.getInstance().getLayoutHelper(model.getEditingDomain());
-	}
-
-	private int getLifelineBodyTop(MLifeline lifeline) {
-		View shape = lifeline.getDiagramView().orElse(null);
-		return layoutHelper()//
-				.getTop(diagramHelper().getLifelineBodyShape(shape));
+	private void execute(Command command) {
+		model.execute(command);
+		/* force reinit after change */
+		interaction = null;
 	}
 
 	private MInteraction interaction() {
 		if (interaction == null) {
-			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+			interaction = model.getMInteraction();
 		}
 		return interaction;
-	}
-
-	private void execute(Command remove) {
-		if (!remove.canExecute()) {
-			Assert.fail("Command not executable"); //$NON-NLS-1$
-		}
-		remove.execute();
-		/* force reinit after change */
-		interaction = null;
 	}
 
 	@Test
@@ -135,7 +112,7 @@ public class CreateMessageTest {
 		assertEquals(lifeline3Top, interaction().getLifelines().get(2).getTop().getAsInt());
 
 		/* we drew the creation message to the middle of the side of the lifeline head */
-		int nudgedLifeline2Top = getLifelineBodyTop(interaction().getLifelines().get(0)) + 10 //
+		int nudgedLifeline2Top = model.getLifelineBodyTop(interaction().getLifelines().get(0)) + 10 //
 				- (lifeline2Header / 2);
 		assertEquals(nudgedLifeline2Top, interaction().getLifelines().get(1).getTop().getAsInt());
 
@@ -177,7 +154,7 @@ public class CreateMessageTest {
 		assertEquals(4, interaction().getMessages().size());
 		assertEquals(MessageSort.CREATE_MESSAGE_LITERAL,
 				interaction().getMessages().get(3).getElement().getMessageSort());
-		assertEquals(getLifelineBodyTop(interaction().getLifelines().get(1)) + 5,
+		assertEquals(model.getLifelineBodyTop(interaction().getLifelines().get(1)) + 5,
 				interaction().getMessages().get(3).getTop().getAsInt());
 
 		assertEquals(lifeline1Top, interaction().getLifelines().get(0).getTop().getAsInt());

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTestB.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/CreateMessageTestB.java
@@ -3,28 +3,22 @@ package org.eclipse.papyrus.uml.interaction.model.tests.creation;
 import static org.junit.Assert.assertEquals;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.gmf.runtime.notation.View;
-import org.eclipse.papyrus.uml.interaction.internal.model.impl.LogicalModelPlugin;
 import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
-import org.eclipse.papyrus.uml.interaction.model.spi.DiagramHelper;
-import org.eclipse.papyrus.uml.interaction.model.spi.LayoutHelper;
-import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.eclipse.uml2.uml.Message;
 import org.eclipse.uml2.uml.MessageSort;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-@SuppressWarnings("restriction")
 @ModelResource({"CreateMessageTestingB.uml", "CreateMessageTestingB.notation" })
 public class CreateMessageTestB {
 
 	@Rule
-	public final ModelFixture.Edit model = new ModelFixture.Edit();
+	public final ModelEditFixture model = new ModelEditFixture();
 
 	private MInteraction interaction;
 
@@ -57,8 +51,8 @@ public class CreateMessageTestB {
 		lifeline3Top = interaction().getLifelines().get(2).getTop().getAsInt();
 		lifeline4Top = interaction().getLifelines().get(3).getTop().getAsInt();
 
-		lifeline2Header = getLifelineBodyTop(interaction().getLifelines().get(1)) - lifeline2Top;
-		lifeline4Header = getLifelineBodyTop(interaction().getLifelines().get(3)) - lifeline4Top;
+		lifeline2Header = model.getLifelineBodyTop(interaction().getLifelines().get(1)) - lifeline2Top;
+		lifeline4Header = model.getLifelineBodyTop(interaction().getLifelines().get(3)) - lifeline4Top;
 
 		message1Top = interaction().getMessages().get(0).getTop().getAsInt();
 		message2Top = interaction().getMessages().get(4).getTop().getAsInt();
@@ -67,34 +61,17 @@ public class CreateMessageTestB {
 		message5Top = interaction().getMessages().get(3).getTop().getAsInt();
 	}
 
-	private DiagramHelper diagramHelper() {
-		return LogicalModelPlugin.getInstance().getDiagramHelper(model.getEditingDomain());
-	}
-
-	private LayoutHelper layoutHelper() {
-		return LogicalModelPlugin.getInstance().getLayoutHelper(model.getEditingDomain());
-	}
-
-	private int getLifelineBodyTop(MLifeline lifeline) {
-		View shape = lifeline.getDiagramView().orElse(null);
-		return layoutHelper()//
-				.getTop(diagramHelper().getLifelineBodyShape(shape));
+	private void execute(Command command) {
+		model.execute(command);
+		/* force reinit after change */
+		interaction = null;
 	}
 
 	private MInteraction interaction() {
 		if (interaction == null) {
-			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+			interaction = model.getMInteraction();
 		}
 		return interaction;
-	}
-
-	private void execute(Command remove) {
-		if (!remove.canExecute()) {
-			Assert.fail("Command not executable"); //$NON-NLS-1$
-		}
-		remove.execute();
-		/* force reinit after change */
-		interaction = null;
 	}
 
 	@Test
@@ -115,7 +92,7 @@ public class CreateMessageTestB {
 		assertEquals(6, interaction().getMessages().size());
 		assertEquals(MessageSort.CREATE_MESSAGE_LITERAL,
 				interaction().getMessages().get(5).getElement().getMessageSort());
-		assertEquals(getLifelineBodyTop(interaction().getLifelines().get(0)) + 10,
+		assertEquals(model.getLifelineBodyTop(interaction().getLifelines().get(0)) + 10,
 				interaction().getMessages().get(5).getTop().getAsInt());
 
 		assertEquals(lifeline1Top, interaction().getLifelines().get(0).getTop().getAsInt());
@@ -156,7 +133,7 @@ public class CreateMessageTestB {
 		assertEquals(6, interaction().getMessages().size());
 		assertEquals(MessageSort.CREATE_MESSAGE_LITERAL,
 				interaction().getMessages().get(5).getElement().getMessageSort());
-		assertEquals(getLifelineBodyTop(interaction().getLifelines().get(2)) + 10,
+		assertEquals(model.getLifelineBodyTop(interaction().getLifelines().get(2)) + 10,
 				interaction().getMessages().get(5).getTop().getAsInt());
 
 		assertEquals(lifeline1Top, interaction().getLifelines().get(0).getTop().getAsInt());

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/SemanticOrderAfterCreationOfElementOnTopTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/SemanticOrderAfterCreationOfElementOnTopTest.java
@@ -1,0 +1,196 @@
+package org.eclipse.papyrus.uml.interaction.model.tests.creation;
+
+import static org.eclipse.uml2.uml.UMLPackage.Literals.ACTION_EXECUTION_SPECIFICATION;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.papyrus.uml.interaction.model.CreationCommand;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.MMessage;
+import org.eclipse.papyrus.uml.interaction.model.MMessageEnd;
+import org.eclipse.papyrus.uml.interaction.model.MOccurrence;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.eclipse.uml2.uml.ExecutionSpecification;
+import org.eclipse.uml2.uml.Message;
+import org.eclipse.uml2.uml.MessageSort;
+import org.junit.Rule;
+import org.junit.Test;
+
+@SuppressWarnings("nls")
+@ModelResource({"SemanticOrderAfterCreationTest.uml", "SemanticOrderAfterCreationTest.notation" })
+public class SemanticOrderAfterCreationOfElementOnTopTest {
+
+	private static final String QN = "343-test::Interaction::%s";
+
+	@Rule
+	public final ModelEditFixture model = new ModelEditFixture();
+
+	private MInteraction interaction;
+
+	private MInteraction interaction() {
+		if (interaction == null) {
+			interaction = model.getMInteraction();
+		}
+		return interaction;
+	}
+
+	private void execute(Command command) {
+		model.execute(command);
+		/* force reinit after change */
+		interaction = null;
+	}
+
+	@Test
+	@SuppressWarnings({"boxing" })
+	public void addMessageOnTopFromLifeline2ToLifeline3() {
+		/* setup */
+		MLifeline lifeline2 = interaction().getLifelines().get(1);
+		MLifeline lifeline3 = interaction().getLifelines().get(2);
+		CreationCommand<Message> command = lifeline2.insertMessageAfter(lifeline2, 10, lifeline3,
+				MessageSort.SYNCH_CALL_LITERAL, null);
+
+		/* act */
+		execute(command);
+
+		/* assert: message ends of added message are sorted in before existing messages */
+		MMessage createdMessage = model.getMMessage(command.get()).get();
+		MMessageEnd createdSend = createdMessage.getSend().get();
+		MMessageEnd createdReceive = createdMessage.getReceive().get();
+		MMessageEnd msg1send = model.getElement(QN, "1s", MMessageEnd.class);
+		MMessageEnd msg1receive = model.getElement(QN, "1r", MMessageEnd.class);
+		MMessageEnd msg2send = model.getElement(QN, "2s", MMessageEnd.class);
+		MMessageEnd msg2receive = model.getElement(QN, "2s", MMessageEnd.class);
+
+		List<MMessageEnd> otherEnds = Arrays.asList(msg1send, msg1receive, msg2send, msg2receive);
+		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdSend, other), is(true)));
+		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdReceive, other), is(true)));
+	}
+
+	@Test
+	@SuppressWarnings({"boxing" })
+	public void addMessageAfterFirstExistingMessageFromLifeline2ToLifeline3() {
+		/* setup */
+		MLifeline lifeline2 = interaction().getLifelines().get(1);
+		MLifeline lifeline3 = interaction().getLifelines().get(2);
+		CreationCommand<Message> command = lifeline2.insertMessageAfter(interaction.getMessages().get(0), 10,
+				lifeline3, MessageSort.SYNCH_CALL_LITERAL, null);
+
+		/* act */
+		execute(command);
+
+		/* assert: message ends of added message are sorted in before existing messages */
+		MMessage createdMessage = model.getMMessage(command.get()).get();
+		MMessageEnd createdSend = createdMessage.getSend().get();
+		MMessageEnd createdReceive = createdMessage.getReceive().get();
+		MMessageEnd msg1send = model.getElement(QN, "1s", MMessageEnd.class);
+		MMessageEnd msg1receive = model.getElement(QN, "1r", MMessageEnd.class);
+		MMessageEnd msg2send = model.getElement(QN, "2s", MMessageEnd.class);
+		MMessageEnd msg2receive = model.getElement(QN, "2s", MMessageEnd.class);
+
+		List<MMessageEnd> endsBefore = Arrays.asList(msg1send, msg1receive);
+		endsBefore.forEach(end -> assertThat(model.isSemanticallyBefore(end, createdSend), is(true)));
+		endsBefore.forEach(end -> assertThat(model.isSemanticallyBefore(end, createdReceive), is(true)));
+
+		List<MMessageEnd> endsAfter = Arrays.asList(msg2send, msg2receive);
+		endsAfter.forEach(end -> assertThat(model.isSemanticallyBefore(createdSend, end), is(true)));
+		endsAfter.forEach(end -> assertThat(model.isSemanticallyBefore(createdReceive, end), is(true)));
+	}
+
+	@Test
+	public void addExecutionOnTopOfLifeline1() {
+		MLifeline lifeline1 = interaction().getLifelines().get(0);
+		addAndAssertExecutionOnTopOfLifeline(lifeline1);
+	}
+
+	@Test
+	public void addExecutionOnTopOfLifeline2() {
+		MLifeline lifeline2 = interaction().getLifelines().get(1);
+		addAndAssertExecutionOnTopOfLifeline(lifeline2);
+	}
+
+	@Test
+	public void addExecutionOnTopOfLifeline3() {
+		MLifeline lifeline3 = interaction().getLifelines().get(2);
+		addAndAssertExecutionOnTopOfLifeline(lifeline3);
+	}
+
+	@SuppressWarnings("boxing")
+	private void addAndAssertExecutionOnTopOfLifeline(MLifeline lifeline) {
+		/* setup */
+		CreationCommand<ExecutionSpecification> command = lifeline.insertExecutionAfter(lifeline, 0, 20,
+				ACTION_EXECUTION_SPECIFICATION);
+
+		/* act */
+		execute(command);
+
+		/* assert: message ends of added message are sorted in before existing messages */
+		MExecution createdExecution = model.getMExecution(command.get()).get();
+		MOccurrence<?> createdStart = createdExecution.getStart().get();
+		MOccurrence<?> createdFinish = createdExecution.getFinish().get();
+		MMessageEnd msg1send = model.getElement(QN, "1s", MMessageEnd.class);
+		MMessageEnd msg1receive = model.getElement(QN, "1r", MMessageEnd.class);
+		MMessageEnd msg2send = model.getElement(QN, "2s", MMessageEnd.class);
+		MMessageEnd msg2receive = model.getElement(QN, "2s", MMessageEnd.class);
+
+		List<MMessageEnd> otherEnds = Arrays.asList(msg1send, msg1receive, msg2send, msg2receive);
+		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdStart, other), is(true)));
+		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdFinish, other), is(true)));
+	}
+
+	@Test
+	@SuppressWarnings({"boxing" })
+	public void addMessageAndExecutionOnTopOfLifeline3() {
+		/* first command to create message */
+		/* setup */
+		MLifeline lifeline2 = interaction().getLifelines().get(1);
+		MLifeline lifeline3 = interaction().getLifelines().get(2);
+		CreationCommand<Message> command = lifeline2.insertMessageAfter(lifeline2, 20, lifeline3,
+				MessageSort.SYNCH_CALL_LITERAL, null);
+
+		/* act */
+		execute(command);
+
+		/* second command to create execution */
+		/* setup */
+		CreationCommand<ExecutionSpecification> command2 = lifeline3.insertExecutionAfter(lifeline3, 0, 20,
+				ACTION_EXECUTION_SPECIFICATION);
+
+		/* act */
+		execute(command2);
+
+		/* assert: message ends of added message are sorted in before existing messages */
+		MMessage createdMessage = model.getMMessage(command.get()).get();
+		MMessageEnd createdSend = createdMessage.getSend().get();
+		MMessageEnd createdReceive = createdMessage.getReceive().get();
+
+		MMessageEnd msg1send = model.getElement(QN, "1s", MMessageEnd.class);
+		MMessageEnd msg1receive = model.getElement(QN, "1r", MMessageEnd.class);
+		MMessageEnd msg2send = model.getElement(QN, "2s", MMessageEnd.class);
+		MMessageEnd msg2receive = model.getElement(QN, "2s", MMessageEnd.class);
+
+		List<MMessageEnd> otherEnds = Arrays.asList(msg1send, msg1receive, msg2send, msg2receive);
+		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdSend, other), is(true)));
+		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdReceive, other), is(true)));
+
+		/*
+		 * assert: message ends of added message and all other messages are sorted in after created execution
+		 */
+		MExecution createdExecution = model.getMExecution(command2.get()).get();
+		MOccurrence<?> createdStart = createdExecution.getStart().get();
+		MOccurrence<?> createdFinish = createdExecution.getFinish().get();
+
+		List<MMessageEnd> createdEnds = Arrays.asList(createdSend, createdReceive);
+		createdEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdStart, other), is(true)));
+		createdEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdFinish, other), is(true)));
+		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdStart, other), is(true)));
+		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdFinish, other), is(true)));
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/SemanticOrderAfterCreationOfElementOnTopTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/SemanticOrderAfterCreationOfElementOnTopTest.java
@@ -66,7 +66,7 @@ public class SemanticOrderAfterCreationOfElementOnTopTest {
 		MMessageEnd msg1send = model.getElement(QN, "1s", MMessageEnd.class);
 		MMessageEnd msg1receive = model.getElement(QN, "1r", MMessageEnd.class);
 		MMessageEnd msg2send = model.getElement(QN, "2s", MMessageEnd.class);
-		MMessageEnd msg2receive = model.getElement(QN, "2s", MMessageEnd.class);
+		MMessageEnd msg2receive = model.getElement(QN, "2r", MMessageEnd.class);
 
 		List<MMessageEnd> otherEnds = Arrays.asList(msg1send, msg1receive, msg2send, msg2receive);
 		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdSend, other), is(true)));
@@ -92,7 +92,7 @@ public class SemanticOrderAfterCreationOfElementOnTopTest {
 		MMessageEnd msg1send = model.getElement(QN, "1s", MMessageEnd.class);
 		MMessageEnd msg1receive = model.getElement(QN, "1r", MMessageEnd.class);
 		MMessageEnd msg2send = model.getElement(QN, "2s", MMessageEnd.class);
-		MMessageEnd msg2receive = model.getElement(QN, "2s", MMessageEnd.class);
+		MMessageEnd msg2receive = model.getElement(QN, "2r", MMessageEnd.class);
 
 		List<MMessageEnd> endsBefore = Arrays.asList(msg1send, msg1receive);
 		endsBefore.forEach(end -> assertThat(model.isSemanticallyBefore(end, createdSend), is(true)));
@@ -137,7 +137,7 @@ public class SemanticOrderAfterCreationOfElementOnTopTest {
 		MMessageEnd msg1send = model.getElement(QN, "1s", MMessageEnd.class);
 		MMessageEnd msg1receive = model.getElement(QN, "1r", MMessageEnd.class);
 		MMessageEnd msg2send = model.getElement(QN, "2s", MMessageEnd.class);
-		MMessageEnd msg2receive = model.getElement(QN, "2s", MMessageEnd.class);
+		MMessageEnd msg2receive = model.getElement(QN, "2r", MMessageEnd.class);
 
 		List<MMessageEnd> otherEnds = Arrays.asList(msg1send, msg1receive, msg2send, msg2receive);
 		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdStart, other), is(true)));
@@ -173,7 +173,7 @@ public class SemanticOrderAfterCreationOfElementOnTopTest {
 		MMessageEnd msg1send = model.getElement(QN, "1s", MMessageEnd.class);
 		MMessageEnd msg1receive = model.getElement(QN, "1r", MMessageEnd.class);
 		MMessageEnd msg2send = model.getElement(QN, "2s", MMessageEnd.class);
-		MMessageEnd msg2receive = model.getElement(QN, "2s", MMessageEnd.class);
+		MMessageEnd msg2receive = model.getElement(QN, "2r", MMessageEnd.class);
 
 		List<MMessageEnd> otherEnds = Arrays.asList(msg1send, msg1receive, msg2send, msg2receive);
 		otherEnds.forEach(other -> assertThat(model.isSemanticallyBefore(createdSend, other), is(true)));

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/SemanticOrderAfterCreationTest.notation
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/SemanticOrderAfterCreationTest.notation
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Zg6BgLWoEeialccYIjRT8w" type="LightweightSequenceDiagram" name="NewLightweightSequenceDiagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_Zg6BgbWoEeialccYIjRT8w" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_Zg6BgrWoEeialccYIjRT8w" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_Zg6Bg7WoEeialccYIjRT8w" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_aBJn0LWoEeialccYIjRT8w" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_aBJn0bWoEeialccYIjRT8w" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_aBJn0rWoEeialccYIjRT8w" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_aBJn07WoEeialccYIjRT8w" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_aBJn1LWoEeialccYIjRT8w" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="SemanticOrderAfterCreationTest.uml#_Z8zTULWoEeialccYIjRT8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aBJn1bWoEeialccYIjRT8w" x="49" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_aIMrALWoEeialccYIjRT8w" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_aIMrAbWoEeialccYIjRT8w" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_aIMrArWoEeialccYIjRT8w" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_aIMrA7WoEeialccYIjRT8w" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_aIMrBLWoEeialccYIjRT8w" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="SemanticOrderAfterCreationTest.uml#_aFf8ULWoEeialccYIjRT8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aIMrBbWoEeialccYIjRT8w" x="204" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_aO9aULWoEeialccYIjRT8w" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_aO9aUbWoEeialccYIjRT8w" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_aO9aUrWoEeialccYIjRT8w" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_aO9aU7WoEeialccYIjRT8w" type="Shape_Lifeline_Body">
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_aO9aVLWoEeialccYIjRT8w" width="2" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="SemanticOrderAfterCreationTest.uml#_aNk6QLWoEeialccYIjRT8w"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_aO9aVbWoEeialccYIjRT8w" x="388" y="25" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Zg6BhLWoEeialccYIjRT8w" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_Zg6BhbWoEeialccYIjRT8w" name="diagram_compatibility_version" stringValue="1.3.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_Zg6BhrWoEeialccYIjRT8w"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_Zg6Bh7WoEeialccYIjRT8w" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="SemanticOrderAfterCreationTest.uml#_YgP1wLWoEeialccYIjRT8w"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="SemanticOrderAfterCreationTest.uml#_YgP1wLWoEeialccYIjRT8w"/>
+  <edges xmi:type="notation:Connector" xmi:id="_cLFIwLWoEeialccYIjRT8w" type="Edge_Message" source="_aBJn07WoEeialccYIjRT8w" target="_aIMrA7WoEeialccYIjRT8w">
+    <element xmi:type="uml:Message" href="SemanticOrderAfterCreationTest.uml#_cLEhsrWoEeialccYIjRT8w"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cLFIwbWoEeialccYIjRT8w"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cLFIwrWoEeialccYIjRT8w" id="52"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cLFIw7WoEeialccYIjRT8w" id="52"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_cmAxQLWoEeialccYIjRT8w" type="Edge_Message" source="_aIMrA7WoEeialccYIjRT8w" target="_aBJn07WoEeialccYIjRT8w">
+    <element xmi:type="uml:Message" href="SemanticOrderAfterCreationTest.uml#_cl_jIbWoEeialccYIjRT8w"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cmAxQbWoEeialccYIjRT8w"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cmAxQrWoEeialccYIjRT8w" id="107"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cmAxQ7WoEeialccYIjRT8w" id="107"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/SemanticOrderAfterCreationTest.uml
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/creation/SemanticOrderAfterCreationTest.uml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_RYFQYLTQEeikCJquPYqrLQ" name="343-test">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_RcCjULTQEeikCJquPYqrLQ">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_YgP1wLWoEeialccYIjRT8w" name="Interaction">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_Z8zTULWoEeialccYIjRT8w" name="Lifeline1" coveredBy="_cLEhsLWoEeialccYIjRT8w _cl_jILWoEeialccYIjRT8w"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_aFf8ULWoEeialccYIjRT8w" name="Lifeline2" coveredBy="_cLEhsbWoEeialccYIjRT8w _cl-8ELWoEeialccYIjRT8w"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_aNk6QLWoEeialccYIjRT8w" name="Lifeline3"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_cLEhsLWoEeialccYIjRT8w" name="1s" covered="_Z8zTULWoEeialccYIjRT8w" message="_cLEhsrWoEeialccYIjRT8w"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_cLEhsbWoEeialccYIjRT8w" name="1r" covered="_aFf8ULWoEeialccYIjRT8w" message="_cLEhsrWoEeialccYIjRT8w"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_cl-8ELWoEeialccYIjRT8w" name="2s" covered="_aFf8ULWoEeialccYIjRT8w" message="_cl_jIbWoEeialccYIjRT8w"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_cl_jILWoEeialccYIjRT8w" name="2r" covered="_Z8zTULWoEeialccYIjRT8w" message="_cl_jIbWoEeialccYIjRT8w"/>
+    <message xmi:type="uml:Message" xmi:id="_cLEhsrWoEeialccYIjRT8w" receiveEvent="_cLEhsbWoEeialccYIjRT8w" sendEvent="_cLEhsLWoEeialccYIjRT8w"/>
+    <message xmi:type="uml:Message" xmi:id="_cl_jIbWoEeialccYIjRT8w" receiveEvent="_cl_jILWoEeialccYIjRT8w" sendEvent="_cl-8ELWoEeialccYIjRT8w"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/BasicDeletionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/BasicDeletionTest.java
@@ -15,7 +15,7 @@ import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
 import org.eclipse.papyrus.uml.interaction.model.spi.RemovalCommand;
-import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
 import org.eclipse.uml2.uml.Element;
 import org.junit.Assert;
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class BasicDeletionTest {
 
 	@Rule
-	public final ModelFixture.Edit model = new ModelFixture.Edit();
+	public final ModelEditFixture model = new ModelEditFixture();
 
 	private MInteraction interaction;
 
@@ -48,7 +48,7 @@ public class BasicDeletionTest {
 
 	private MInteraction interaction() {
 		if (interaction == null) {
-			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+			interaction = model.getMInteraction();
 		}
 		return interaction;
 	}
@@ -70,7 +70,6 @@ public class BasicDeletionTest {
 
 		/* force reinit after change */
 		interaction = null;
-
 	}
 
 	@SuppressWarnings("unchecked")

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/CreationMessageDeletionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/CreationMessageDeletionTest.java
@@ -5,9 +5,8 @@ import static org.junit.Assert.assertEquals;
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
-import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,7 +15,7 @@ import org.junit.Test;
 public class CreationMessageDeletionTest {
 
 	@Rule
-	public final ModelFixture.Edit model = new ModelFixture.Edit();
+	public final ModelEditFixture model = new ModelEditFixture();
 
 	private MInteraction interaction;
 
@@ -64,16 +63,13 @@ public class CreationMessageDeletionTest {
 
 	private MInteraction interaction() {
 		if (interaction == null) {
-			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+			interaction = model.getMInteraction();
 		}
 		return interaction;
 	}
 
-	private void execute(Command remove) {
-		if (!remove.canExecute()) {
-			Assert.fail("Command not executable"); //$NON-NLS-1$
-		}
-		remove.execute();
+	private void execute(Command command) {
+		model.execute(command);
 		/* force reinit after change */
 		interaction = null;
 	}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTest.java
@@ -19,9 +19,8 @@ import org.eclipse.papyrus.uml.interaction.model.MExecution;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MLifeline;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
-import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,7 +30,7 @@ import org.junit.Test;
 public class DeleteExecutionTest {
 
 	@Rule
-	public final ModelFixture.Edit model = new ModelFixture.Edit();
+	public final ModelEditFixture model = new ModelEditFixture();
 
 	private MInteraction interaction;
 
@@ -89,16 +88,13 @@ public class DeleteExecutionTest {
 
 	private MInteraction interaction() {
 		if (interaction == null) {
-			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+			interaction = model.getMInteraction();
 		}
 		return interaction;
 	}
 
 	private void execute(Command command) {
-		if (!command.canExecute()) {
-			Assert.fail("Command not executable"); //$NON-NLS-1$
-		}
-		command.execute();
+		model.execute(command);
 		/* force reinit after change */
 		interaction = null;
 	}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTest.java
@@ -1,0 +1,221 @@
+/*****************************************************************************
+ * Copyright (c) 2018 Philip Langer and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Philip Langer - Initial API and implementation
+ *****************************************************************************/
+package org.eclipse.papyrus.uml.interaction.model.tests.deletion;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.papyrus.uml.interaction.model.MExecution;
+import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.MLifeline;
+import org.eclipse.papyrus.uml.interaction.model.MMessage;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+@ModelResource({"DeleteExecutionTesting.uml", "DeleteExecutionTesting.notation" })
+@SuppressWarnings("boxing")
+public class DeleteExecutionTest {
+
+	@Rule
+	public final ModelFixture.Edit model = new ModelFixture.Edit();
+
+	private MInteraction interaction;
+
+	private int execution1OfLifeline1Top;
+
+	private int execution2OfLifeline1Top;
+
+	private int totalHeightExecution1Lifeline1;
+
+	private int totalHeightExecution2Lifeline1;
+
+	private int execution1OfLifeline2Top;
+
+	private int execution2OfLifeline2Top;
+
+	private int totalHeightExecution1Lifeline2;
+
+	private int totalHeightExecution2Lifeline2;
+
+	private int message1Top;
+
+	private int message2Top;
+
+	private int message3Top;
+
+	private int message4Top;
+
+	@Before
+	public void before() {
+		message1Top = messageAt(0).getTop().getAsInt();
+		message2Top = messageAt(1).getTop().getAsInt();
+		message3Top = messageAt(2).getTop().getAsInt();
+		message4Top = messageAt(3).getTop().getAsInt();
+
+		MLifeline lifeline1 = lifelineAt(0);
+		MExecution execution1OfLifeline1 = lifeline1.getExecutions().get(0);
+		MExecution execution2OfLifeline1 = lifeline1.getExecutions().get(1);
+		execution1OfLifeline1Top = execution1OfLifeline1.getTop().getAsInt();
+		execution2OfLifeline1Top = execution2OfLifeline1.getTop().getAsInt();
+		// see DeleteExecutionTesting.notation:12 -- height = 40; y = 20
+		totalHeightExecution1Lifeline1 = 40 + 20;
+		// see DeleteExecutionTesting.notation:16 -- height = 40; y = 78
+		totalHeightExecution2Lifeline1 = 40 + 78 - totalHeightExecution1Lifeline1;
+
+		MLifeline lifeline2 = lifelineAt(1);
+		MExecution execution1OfLifeline2 = lifeline2.getExecutions().get(0);
+		MExecution execution2OfLifeline2 = lifeline2.getExecutions().get(1);
+		execution1OfLifeline2Top = execution1OfLifeline2.getTop().getAsInt();
+		execution2OfLifeline2Top = execution2OfLifeline2.getTop().getAsInt();
+		// see DeleteExecutionTesting.notation:29 -- height = 30; y = 122
+		totalHeightExecution1Lifeline2 = 30 + 122;
+		// see DeleteExecutionTesting.notation:33 -- height = 36; y = 167
+		totalHeightExecution2Lifeline2 = 36 + 167 - totalHeightExecution1Lifeline2;
+	}
+
+	private MInteraction interaction() {
+		if (interaction == null) {
+			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+		}
+		return interaction;
+	}
+
+	private void execute(Command command) {
+		if (!command.canExecute()) {
+			Assert.fail("Command not executable"); //$NON-NLS-1$
+		}
+		command.execute();
+		/* force reinit after change */
+		interaction = null;
+	}
+
+	@Test
+	public void deletionOfFirstExecutionOfLifeline1() {
+		/* setup */
+		Command command = executionAt(0, 0).remove();
+
+		/* act */
+		execute(command);
+
+		/*
+		 * assert: Only one execution left on lifeline1 and all other executions and all messages moved up
+		 */
+		assertThat(lifelineAt(0).getExecutions().size(), is(1));
+		assertThat(executionAt(0, 0).getTop().getAsInt(),
+				is(execution2OfLifeline1Top - totalHeightExecution1Lifeline1));
+
+		assertThat(lifelineAt(1).getExecutions().size(), is(2));
+		assertThat(executionAt(1, 0).getTop().getAsInt(),
+				is(execution1OfLifeline2Top - totalHeightExecution1Lifeline1));
+		assertThat(executionAt(1, 1).getTop().getAsInt(),
+				is(execution2OfLifeline2Top - totalHeightExecution1Lifeline1));
+
+		assertThat(messageAt(0).getTop().getAsInt(), is(message1Top - totalHeightExecution1Lifeline1));
+		assertThat(messageAt(1).getTop().getAsInt(), is(message2Top - totalHeightExecution1Lifeline1));
+		assertThat(messageAt(2).getTop().getAsInt(), is(message3Top - totalHeightExecution1Lifeline1));
+		assertThat(messageAt(3).getTop().getAsInt(), is(message4Top - totalHeightExecution1Lifeline1));
+	}
+
+	@Test
+	public void deletionOfSecondExecutionOfLifeline1() {
+		/* setup */
+		Command command = executionAt(0, 1).remove();
+
+		/* act */
+		execute(command);
+
+		/* assert only one execution left on lifeline1 */
+		assertThat(lifelineAt(0).getExecutions().size(), is(1));
+		assertThat(executionAt(0, 0).getTop().getAsInt(), is(execution1OfLifeline1Top));
+
+		/* assert first execution hasn't been moved */
+		assertThat(lifelineAt(1).getExecutions().size(), is(2));
+		assertThat(executionAt(1, 0).getTop().getAsInt(),
+				is(execution1OfLifeline2Top - totalHeightExecution2Lifeline1));
+		assertThat(executionAt(1, 1).getTop().getAsInt(),
+				is(execution2OfLifeline2Top - totalHeightExecution2Lifeline1));
+
+		/* assert all other executions and all messages moved up */
+		assertThat(messageAt(0).getTop().getAsInt(), is(message1Top - totalHeightExecution2Lifeline1));
+		assertThat(messageAt(1).getTop().getAsInt(), is(message2Top - totalHeightExecution2Lifeline1));
+		assertThat(messageAt(2).getTop().getAsInt(), is(message3Top - totalHeightExecution2Lifeline1));
+		assertThat(messageAt(3).getTop().getAsInt(), is(message4Top - totalHeightExecution2Lifeline1));
+	}
+
+	@Test
+	public void deletionOfFirstExecutionOfLifeline2() {
+		/* setup */
+		Command command = executionAt(1, 0).remove();
+
+		/* act */
+		execute(command);
+
+		/* assert only one execution left on lifeline2 and both executions on lifeline1 */
+		assertThat(lifelineAt(1).getExecutions().size(), is(1));
+		assertThat(lifelineAt(0).getExecutions().size(), is(2));
+
+		/* assert executions on lifeline1 haven't been moved */
+		assertThat(executionAt(0, 0).getTop().getAsInt(), is(execution1OfLifeline1Top));
+		assertThat(executionAt(0, 1).getTop().getAsInt(), is(execution2OfLifeline1Top));
+
+		/* assert the remaining execution on lifeline2 moved up and all messages moved up */
+		int pullUpDelta = totalHeightExecution1Lifeline2 - totalHeightExecution1Lifeline1
+				- totalHeightExecution2Lifeline1;
+		assertThat(executionAt(1, 0).getTop().getAsInt(), is(execution2OfLifeline2Top - pullUpDelta));
+		assertThat(messageAt(0).getTop().getAsInt(), is(message1Top - pullUpDelta));
+		assertThat(messageAt(1).getTop().getAsInt(), is(message2Top - pullUpDelta));
+		assertThat(messageAt(2).getTop().getAsInt(), is(message3Top - pullUpDelta));
+		assertThat(messageAt(3).getTop().getAsInt(), is(message4Top - pullUpDelta));
+	}
+
+	@Test
+	public void deletionOfSecondExecutionOfLifeline2() {
+		/* setup */
+		Command command = executionAt(1, 1).remove();
+
+		/* act */
+		execute(command);
+
+		/* assert only one execution left on lifeline2 and both executions on lifeline1 */
+		assertThat(lifelineAt(1).getExecutions().size(), is(1));
+		assertThat(lifelineAt(0).getExecutions().size(), is(2));
+
+		/* assert executions on lifeline1 and remaining on lifeline2 haven't been moved */
+		assertThat(executionAt(0, 0).getTop().getAsInt(), is(execution1OfLifeline1Top));
+		assertThat(executionAt(0, 1).getTop().getAsInt(), is(execution2OfLifeline1Top));
+		assertThat(executionAt(1, 0).getTop().getAsInt(), is(execution1OfLifeline2Top));
+
+		/* assert all messages moved up */
+		assertThat(messageAt(0).getTop().getAsInt(), is(message1Top - totalHeightExecution2Lifeline2));
+		assertThat(messageAt(1).getTop().getAsInt(), is(message2Top - totalHeightExecution2Lifeline2));
+		assertThat(messageAt(2).getTop().getAsInt(), is(message3Top - totalHeightExecution2Lifeline2));
+		assertThat(messageAt(3).getTop().getAsInt(), is(message4Top - totalHeightExecution2Lifeline2));
+	}
+
+	private MExecution executionAt(int lifelineIndex, int executionIndex) {
+		return lifelineAt(lifelineIndex).getExecutions().get(executionIndex);
+	}
+
+	protected MLifeline lifelineAt(int lifelineIndex) {
+		return interaction().getLifelines().get(lifelineIndex);
+	}
+
+	private MMessage messageAt(int messageIndex) {
+		return interaction().getMessages().get(messageIndex);
+	}
+
+}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTesting.notation
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTesting.notation
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_kCqjwLA8EeiVu8M2BzYNdA" type="LightweightSequenceDiagram" name="Lightweight Sequence Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_kCqjwbA8EeiVu8M2BzYNdA" type="Shape_Interaction">
+    <children xmi:type="notation:DecorationNode" xmi:id="_kCqjwrA8EeiVu8M2BzYNdA" type="Label_Interaction_Name"/>
+    <children xmi:type="notation:Compartment" xmi:id="_kCqjw7A8EeiVu8M2BzYNdA" type="Interaction_Contents">
+      <children xmi:type="notation:Shape" xmi:id="_k3YlQLA8EeiVu8M2BzYNdA" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQbA8EeiVu8M2BzYNdA" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQrA8EeiVu8M2BzYNdA" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_k3YlQ7A8EeiVu8M2BzYNdA" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_Jx7QQLD_Eeif-f3-rx6-Ug" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="DeleteExecutionTesting.uml#_Jvm8ELD_Eeif-f3-rx6-Ug"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Jx7QQbD_Eeif-f3-rx6-Ug" x="70" y="20" width="10" height="40"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_N6yjELD_Eeif-f3-rx6-Ug" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="DeleteExecutionTesting.uml#_N1qygLD_Eeif-f3-rx6-Ug"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_N6yjEbD_Eeif-f3-rx6-Ug" x="70" y="78" width="10" height="40"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_k3YlRLA8EeiVu8M2BzYNdA" width="150" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="DeleteExecutionTesting.uml#_kxgmwLA8EeiVu8M2BzYNdA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_k3YlRbA8EeiVu8M2BzYNdA" x="29" y="25" width="100" height="28"/>
+      </children>
+      <children xmi:type="notation:Shape" xmi:id="_lH4fYLA8EeiVu8M2BzYNdA" type="Shape_Lifeline_Header">
+        <children xmi:type="notation:Shape" xmi:id="_lH4fYbA8EeiVu8M2BzYNdA" type="Compartment_Lifeline_Header"/>
+        <children xmi:type="notation:Shape" xmi:id="_lH4fYrA8EeiVu8M2BzYNdA" type="Label_Lifeline_Name"/>
+        <children xmi:type="notation:Shape" xmi:id="_lH4fY7A8EeiVu8M2BzYNdA" type="Shape_Lifeline_Body">
+          <children xmi:type="notation:Shape" xmi:id="_TqyGYLDsEeip79oPPjBVbA" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="DeleteExecutionTesting.uml#_ToF-wLDsEeip79oPPjBVbA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_TqyGYbDsEeip79oPPjBVbA" x="70" y="122" width="10" height="30"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_bS7eULD-Eeip79oPPjBVbA" type="Shape_Execution_Specification">
+            <element xmi:type="uml:ActionExecutionSpecification" href="DeleteExecutionTesting.uml#_bL1X0LD-Eeip79oPPjBVbA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bS7eUbD-Eeip79oPPjBVbA" x="70" y="167" width="10" height="36"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Size" xmi:id="_lH4fZLA8EeiVu8M2BzYNdA" width="150" height="150"/>
+        </children>
+        <element xmi:type="uml:Lifeline" href="DeleteExecutionTesting.uml#_k9yvQLA8EeiVu8M2BzYNdA"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_lH4fZbA8EeiVu8M2BzYNdA" x="164" y="25" width="100" height="28"/>
+      </children>
+    </children>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kCqjxLA8EeiVu8M2BzYNdA" x="37" y="12" width="600" height="450"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_kCqjxbA8EeiVu8M2BzYNdA" name="diagram_compatibility_version" stringValue="1.3.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_kCqjxrA8EeiVu8M2BzYNdA"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_kCqjx7A8EeiVu8M2BzYNdA" diagramKindId="org.eclipse.papyrus.uml.diagram.lightweightsequence">
+    <owner xmi:type="uml:Interaction" href="DeleteExecutionTesting.uml#_kCRiMLA8EeiVu8M2BzYNdA"/>
+  </styles>
+  <element xmi:type="uml:Interaction" href="DeleteExecutionTesting.uml#_kCRiMLA8EeiVu8M2BzYNdA"/>
+  <edges xmi:type="notation:Connector" xmi:id="_mX-1ULA8EeiVu8M2BzYNdA" type="Edge_Message" source="_k3YlQ7A8EeiVu8M2BzYNdA" target="_lH4fY7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="DeleteExecutionTesting.uml#_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mX-1UbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX-1UrA8EeiVu8M2BzYNdA" id="229"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mX-1U7A8EeiVu8M2BzYNdA" id="229"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_mzDnwLA8EeiVu8M2BzYNdA" type="Edge_Message" source="_lH4fY7A8EeiVu8M2BzYNdA" target="_k3YlQ7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="DeleteExecutionTesting.uml#_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mzDnwbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mzDnwrA8EeiVu8M2BzYNdA" id="258"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mzDnw7A8EeiVu8M2BzYNdA" id="258"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_nM8HY7A8EeiVu8M2BzYNdA" type="Edge_Message" source="_k3YlQ7A8EeiVu8M2BzYNdA" target="_lH4fY7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="DeleteExecutionTesting.uml#_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nM8HZLA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nM8HZbA8EeiVu8M2BzYNdA" id="305"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nM8HZrA8EeiVu8M2BzYNdA" id="305"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_nr-MwLA8EeiVu8M2BzYNdA" type="Edge_Message" source="_lH4fY7A8EeiVu8M2BzYNdA" target="_k3YlQ7A8EeiVu8M2BzYNdA">
+    <element xmi:type="uml:Message" href="DeleteExecutionTesting.uml#_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nr-MwbA8EeiVu8M2BzYNdA"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nr-MwrA8EeiVu8M2BzYNdA" id="335"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nr-Mw7A8EeiVu8M2BzYNdA" id="335"/>
+  </edges>
+</notation:Diagram>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTesting.uml
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeleteExecutionTesting.uml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_kBamkLA8EeiVu8M2BzYNdA" name="CreateExecutionTesting">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_kKeb8LA8EeiVu8M2BzYNdA">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:Interaction" xmi:id="_kCRiMLA8EeiVu8M2BzYNdA" name="Interaction1">
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_kxgmwLA8EeiVu8M2BzYNdA" name="Lifeline1" coveredBy="_mX8ZELA8EeiVu8M2BzYNdA _mzBykLA8EeiVu8M2BzYNdA _nM8HYLA8EeiVu8M2BzYNdA _nr8XkLA8EeiVu8M2BzYNdA _JvnjILD_Eeif-f3-rx6-Ug _Jvm8ELD_Eeif-f3-rx6-Ug _JvnjIbD_Eeif-f3-rx6-Ug _N1qygbD_Eeif-f3-rx6-Ug _N1qygLD_Eeif-f3-rx6-Ug _N1rZkLD_Eeif-f3-rx6-Ug"/>
+    <lifeline xmi:type="uml:Lifeline" xmi:id="_k9yvQLA8EeiVu8M2BzYNdA" name="Lifeline2" coveredBy="_mX9AILA8EeiVu8M2BzYNdA _mzBLgLA8EeiVu8M2BzYNdA _nM8HYbA8EeiVu8M2BzYNdA _nr7wgLA8EeiVu8M2BzYNdA _ToGl0LDsEeip79oPPjBVbA _ToF-wLDsEeip79oPPjBVbA _ToHz8LDsEeip79oPPjBVbA _bL1X0bD-Eeip79oPPjBVbA _bL1X0LD-Eeip79oPPjBVbA _bL1X0rD-Eeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_JvnjILD_Eeif-f3-rx6-Ug" covered="_kxgmwLA8EeiVu8M2BzYNdA" execution="_Jvm8ELD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_Jvm8ELD_Eeif-f3-rx6-Ug" name="Execution3" covered="_kxgmwLA8EeiVu8M2BzYNdA" finish="_JvnjIbD_Eeif-f3-rx6-Ug" start="_JvnjILD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_JvnjIbD_Eeif-f3-rx6-Ug" covered="_kxgmwLA8EeiVu8M2BzYNdA" execution="_Jvm8ELD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_N1qygbD_Eeif-f3-rx6-Ug" covered="_kxgmwLA8EeiVu8M2BzYNdA" execution="_N1qygLD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_N1qygLD_Eeif-f3-rx6-Ug" name="Execution4" covered="_kxgmwLA8EeiVu8M2BzYNdA" finish="_N1rZkLD_Eeif-f3-rx6-Ug" start="_N1qygbD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_N1rZkLD_Eeif-f3-rx6-Ug" covered="_kxgmwLA8EeiVu8M2BzYNdA" execution="_N1qygLD_Eeif-f3-rx6-Ug"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mX8ZELA8EeiVu8M2BzYNdA" name="msg1_send" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_ToGl0LDsEeip79oPPjBVbA" covered="_k9yvQLA8EeiVu8M2BzYNdA" execution="_ToF-wLDsEeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_ToF-wLDsEeip79oPPjBVbA" name="Execution1" covered="_k9yvQLA8EeiVu8M2BzYNdA" finish="_ToHz8LDsEeip79oPPjBVbA" start="_ToGl0LDsEeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_ToHz8LDsEeip79oPPjBVbA" covered="_k9yvQLA8EeiVu8M2BzYNdA" execution="_ToF-wLDsEeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_bL1X0bD-Eeip79oPPjBVbA" covered="_k9yvQLA8EeiVu8M2BzYNdA" execution="_bL1X0LD-Eeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ActionExecutionSpecification" xmi:id="_bL1X0LD-Eeip79oPPjBVbA" name="Execution2" covered="_k9yvQLA8EeiVu8M2BzYNdA" finish="_bL1X0rD-Eeip79oPPjBVbA" start="_bL1X0bD-Eeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:ExecutionOccurrenceSpecification" xmi:id="_bL1X0rD-Eeip79oPPjBVbA" covered="_k9yvQLA8EeiVu8M2BzYNdA" execution="_bL1X0LD-Eeip79oPPjBVbA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mX9AILA8EeiVu8M2BzYNdA" name="msg1_receive" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_mX9nMLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mzBLgLA8EeiVu8M2BzYNdA" name="msg2_send" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_mzBykLA8EeiVu8M2BzYNdA" name="msg2_receive" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_mzCZoLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nM8HYLA8EeiVu8M2BzYNdA" name="msg3_send" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nM8HYbA8EeiVu8M2BzYNdA" name="msg3_receive" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_nM8HYrA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nr7wgLA8EeiVu8M2BzYNdA" name="msg4_send" covered="_k9yvQLA8EeiVu8M2BzYNdA" message="_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_nr8XkLA8EeiVu8M2BzYNdA" name="msg4_receive" covered="_kxgmwLA8EeiVu8M2BzYNdA" message="_nr8-oLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_mX9nMLA8EeiVu8M2BzYNdA" name="msg1" receiveEvent="_mX9AILA8EeiVu8M2BzYNdA" sendEvent="_mX8ZELA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_mzCZoLA8EeiVu8M2BzYNdA" name="ms2" receiveEvent="_mzBykLA8EeiVu8M2BzYNdA" sendEvent="_mzBLgLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_nM8HYrA8EeiVu8M2BzYNdA" name="msg3" receiveEvent="_nM8HYbA8EeiVu8M2BzYNdA" sendEvent="_nM8HYLA8EeiVu8M2BzYNdA"/>
+    <message xmi:type="uml:Message" xmi:id="_nr8-oLA8EeiVu8M2BzYNdA" name="msg4" receiveEvent="_nr8XkLA8EeiVu8M2BzYNdA" sendEvent="_nr7wgLA8EeiVu8M2BzYNdA"/>
+  </packagedElement>
+</uml:Model>

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeletionMessageDeletionTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/tests/deletion/DeletionMessageDeletionTest.java
@@ -5,9 +5,8 @@ import static org.junit.Assert.assertEquals;
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.papyrus.uml.interaction.model.MInteraction;
 import org.eclipse.papyrus.uml.interaction.model.MMessage;
-import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,7 +15,7 @@ import org.junit.Test;
 public class DeletionMessageDeletionTest {
 
 	@Rule
-	public final ModelFixture.Edit model = new ModelFixture.Edit();
+	public final ModelEditFixture model = new ModelEditFixture();
 
 	private MInteraction interaction;
 
@@ -40,16 +39,13 @@ public class DeletionMessageDeletionTest {
 
 	private MInteraction interaction() {
 		if (interaction == null) {
-			interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
+			interaction = model.getMInteraction();
 		}
 		return interaction;
 	}
 
-	private void execute(Command remove) {
-		if (!remove.canExecute()) {
-			Assert.fail("Command not executable"); //$NON-NLS-1$
-		}
-		remove.execute();
+	private void execute(Command command) {
+		model.execute(command);
 		/* force reinit after change */
 		interaction = null;
 	}

--- a/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/util/tests/LogicalModelPredicatesTest.java
+++ b/tests/org.eclipse.papyrus.uml.interaction.model.tests/src/org/eclipse/papyrus/uml/interaction/model/util/tests/LogicalModelPredicatesTest.java
@@ -17,78 +17,53 @@ import static org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredica
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.util.Optional;
-
 import org.eclipse.papyrus.uml.interaction.model.MElement;
-import org.eclipse.papyrus.uml.interaction.model.MInteraction;
+import org.eclipse.papyrus.uml.interaction.model.tests.ModelEditFixture;
 import org.eclipse.papyrus.uml.interaction.model.util.LogicalModelPredicates;
-import org.eclipse.papyrus.uml.interaction.tests.rules.ModelFixture;
 import org.eclipse.papyrus.uml.interaction.tests.rules.ModelResource;
-import org.eclipse.uml2.uml.Element;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * Unit tests for the {@link LogicalModelPredicates} class.
  */
+@SuppressWarnings({"boxing", "nls" })
 @ModelResource({"AnchorsModel.di", "AnchorsModel.uml", "AnchorsModel.notation" })
 public class LogicalModelPredicatesTest {
 
-	@Rule
-	public final ModelFixture model = new ModelFixture.Edit();
+	private static final String QN = "AnchorsModel::ExecutionSpecificationAnchors::%s";
 
-	private MInteraction interaction;
+	@Rule
+	public final ModelEditFixture model = new ModelEditFixture();
 
 	@Test
 	public void above_int() {
-		MElement<?> requestRecv = getElement("request-recv");
+		MElement<?> requestRecv = model.getElement(QN, "request-recv");
 		assertThat(above(150).test(requestRecv), is(true));
 		assertThat(above(50).test(requestRecv), is(false));
 	}
 
 	@Test
 	public void above_MElement() {
-		MElement<?> requestRecv = getElement("request-recv");
-		MElement<?> replySend = getElement("reply-send");
+		MElement<?> requestRecv = model.getElement(QN, "request-recv");
+		MElement<?> replySend = model.getElement(QN, "reply-send");
 		assertThat(above(replySend).test(requestRecv), is(true));
 		assertThat(above(requestRecv).test(replySend), is(false));
 	}
 
 	@Test
 	public void below_int() {
-		MElement<?> requestRecv = getElement("request-recv");
+		MElement<?> requestRecv = model.getElement(QN, "request-recv");
 		assertThat(below(50).test(requestRecv), is(true));
 		assertThat(below(150).test(requestRecv), is(false));
 	}
 
 	@Test
 	public void below_MElement() {
-		MElement<?> requestRecv = getElement("request-recv");
-		MElement<?> replySend = getElement("reply-send");
+		MElement<?> requestRecv = model.getElement(QN, "request-recv");
+		MElement<?> replySend = model.getElement(QN, "reply-send");
 		assertThat(below(requestRecv).test(replySend), is(true));
 		assertThat(below(replySend).test(requestRecv), is(false));
 	}
 
-	//
-	// Test framework
-	//
-
-	@Before
-	public void setup() {
-		interaction = MInteraction.getInstance(model.getInteraction(), model.getSequenceDiagram().get());
-	}
-
-	public <T extends MElement<? extends Element>> T getElement(String name, Class<T> type) {
-		String qName = String.format("AnchorsModel::ExecutionSpecificationAnchors::%s", name);
-
-		Element element = model.getElement(qName);
-		return Optional.ofNullable(element).flatMap(interaction::getElement).filter(type::isInstance)
-				.map(type::cast).orElseThrow(() -> new AssertionError("no such element: " + name));
-	}
-
-	@SuppressWarnings("unchecked")
-	public <T extends MElement<? extends Element>> T getElement(String name) {
-		return (T)getElement(name, MElement.class);
-	}
 }


### PR DESCRIPTION
Adds tests for issues #343 and #347. To enable more efficient adding of
testing, this change also refactors the tests a bit and extracts common
methods into dedicated model fixture.